### PR TITLE
fix: Set redirect URL in auth middleware catch

### DIFF
--- a/frontend/src/pages/middlewares/authenticate.tsx
+++ b/frontend/src/pages/middlewares/authenticate.tsx
@@ -6,6 +6,8 @@ import { ROUTE_PATHS } from "@app/const/routes";
 import { userKeys } from "@app/hooks/api";
 import { authKeys, fetchAuthToken } from "@app/hooks/api/auth/queries";
 import { clearSession, fetchUserDetails, logoutUser } from "@app/hooks/api/users/queries";
+import { SessionStorageKeys } from "@app/const.ts";
+import { addSeconds, formatISO } from "date-fns";
 
 export const Route = createFileRoute("/_authenticate")({
   beforeLoad: async ({ context, location }) => {
@@ -24,6 +26,14 @@ export const Route = createFileRoute("/_authenticate")({
           title: "Access Restricted",
           text: " You need to log in to access this page. Please log in to continue."
         });
+        sessionStorage.setItem(
+          SessionStorageKeys.ORG_LOGIN_SUCCESS_REDIRECT_URL,
+          JSON.stringify({
+            expiry: formatISO(addSeconds(new Date(), 60)),
+            data: window.location.href
+          })
+        );
+
         throw redirect({
           to: "/login"
         });


### PR DESCRIPTION
# Description 📣
This PR improves login redirection by universally setting the ORG_LOGIN_SUCCESS_REDIRECT_URL session value before the page is redirected via the `authenticate.tsx` middleware. 

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️



To reproduce:
1. Copy any infisical dashboard deep link
2. Access the link in a clean browser that does not contain your session token, i.e. incognito mode.
3. Login once you are redirected from the original deep link, then get automatically redirected.

Before:
You would login and be redirected to the overview page, with the exception of secret sharing links.

Now:
After logging in to any page validated by `authenticate.tsx`, you will now be redirected back to the original deep link. 

Validated on:
http://localhost:8080/organization/secret-scanning
Secret Manager change request approval page. ex: `http://localhost:8080/secret-manager/c88fccda-111c-4876-b1b6-d5e31c0bb77c/approval?requestId=`

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->