### PR TITLE
Fix unset requestId param when selecting an approval request

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
@@ -6,7 +6,7 @@ import {
   faCodeBranch
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { formatDistance } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -70,6 +70,7 @@ export const SecretApprovalRequest = () => {
   const search = useSearch({
     from: ROUTE_PATHS.SecretManager.ApprovalPage.id
   });
+  const navigate = useNavigate();
 
   const { permission } = useProjectPermission();
   const { data: members } = useGetWorkspaceUsers(workspaceId);
@@ -234,7 +235,17 @@ export const SecretApprovalRequest = () => {
                       className="flex flex-col px-8 py-4 hover:bg-mineshaft-700"
                       role="button"
                       tabIndex={0}
-                      onClick={() => setSelectedApprovalId(secretApproval.id)}
+                      onClick={() => {
+                        setSelectedApprovalId(secretApproval.id);
+                        navigate({
+                          to: "." as const,
+                          search: (old: any) => ({
+                            ...old,
+                            requestId: secretApproval.id
+                          }),
+                          replace: true
+                        });
+                      }}
                       onKeyDown={(evt) => {
                         if (evt.key === "Enter") setSelectedApprovalId(secretApproval.id);
                       }}


### PR DESCRIPTION
# Description 📣

Currently, clicking a pending change request does not update the URL parameters, making sharing a specific request ID by link difficult. This PR sets the query params when a specific request is clicked.
Previously, clicking a request would show the link as:
http://localhost:8080/secret-manager/c88fccda-111c-4876-b1b6-d5e31c0bb77c/approval?requestId=

Now:
http://localhost:8080/secret-manager/c88fccda-111c-4876-b1b6-d5e31c0bb77c/approval?requestId=e2bc2b03-262a-40d5-be88-0b52787d20e1 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->